### PR TITLE
bst: update bst to reflect latest SPN reference style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Install TeX Live
         run: |
+          sudo apt-get update
           sudo apt install texlive-latex-extra texlive-science
 
       - name: Install USGS LaTeX style files and Univers font

--- a/usgsLaTeX/bibtex/bst/usgs.bst
+++ b/usgsLaTeX/bibtex/bst/usgs.bst
@@ -50,8 +50,8 @@
 %% ***  notes added with first word lowercase (bug in 2.1 fixed)
 %% ***  and journal `number' never output
 %% ***  abbreviation for grl corrected)
-%% *** 
-%% 
+%% ***
+%%
 %% Copyright 1994-2008 Patrick W Daly
  % ===============================================================
  % IMPORTANT NOTICE:
@@ -174,6 +174,7 @@ FUNCTION {outputc.nonnull}
   if$
   s
 }
+
 FUNCTION {output}
 { duplicate$ empty$
     'pop$
@@ -310,10 +311,13 @@ FUNCTION {bbl.volume}
 { "v." }
 
 FUNCTION {bbl.of}
-{ "of" }
+{ "\emph{of}" }
 
 FUNCTION {bbl.number}
 { "no." }
+
+FUNCTION {bbl.numbers}
+{ "nos." }
 
 FUNCTION {bbl.nr}
 { "no." }
@@ -328,7 +332,7 @@ FUNCTION {bbl.page}
 { "p." }
 
 FUNCTION {bbl.chapter}
-{ "Chap." }
+{ "chap." }
 
 FUNCTION {bbl.techrep}
 %{ "Tech. Rep." } REMOVE THE TECH REPORT WORDS FOR USGS
@@ -707,20 +711,28 @@ FUNCTION {format.onlyfirst}
     fm empty$ {
        % If empty (no first name), use the standard formatting
        ss #1 "{vv~}{ll}{, f{.}.}{, jj}" format.name$
-    }{ % Otherwise, attempt the trick
+    }{
+        %% Otherwise, attempt the trick
         %% Now the trick. Interpret "First Medium"
         %% as if "Medium" were a last name, and abbreviate it
-        fm #1 "{f.}{l}" format.name$ 'tt :=   %% And store the result in tt
-        %% Consider the particular case in which no Medium name is present
-        %% In this case, "First" will be interpreted as a last name, and
-        %% thus abbreviated. This can be detected because the resulting
-        %% string has length 1
-        tt text.length$ #1 > { %% If there was a medium name
-            fm #1 "{f.}{l.}" format.name$ 'tt :=
-            tt  %% Store the abbreviated version
-            }{  %% Else store the original version of the name
-            fm
-            } if$
+        fm #1 "{f.}{l.}" format.name$ 'tt :=   %% And store the result in tt
+        tt  %% Store the abbreviated version
+
+        %%
+        %% Retain this code in the event that the USGS reverts to using the full
+        %% first name for authors without a middle name
+        %%
+        %% %% Consider the particular case in which no Medium name is present
+        %% %% In this case, "First" will be interpreted as a last name, and
+        %% %% thus abbreviated. This can be detected because the resulting
+        %% %% string has length 1
+        %% tt text.length$ #1 > { %% If there was a medium name
+        %%     fm #1 "{f.}{l.}" format.name$ 'tt :=
+        %%     tt  %% Store the abbreviated version
+        %%     }{ %% just initial for first name
+        %%     %% Else store the original version of the name
+        %%     fm
+        %%     } if$
 
         %% After the above, the top of the stack will contain
         %% either "First" unabbreviated (if the author has not middle name)
@@ -853,10 +865,10 @@ FUNCTION {get.bbl.editor}
 FUNCTION {format.editors}
 { editor "editor" format.names duplicate$ empty$ 'skip$
     {
-      " " *
+      ", " *
       get.bbl.editor
-      capitalize
-   "(" swap$ * ")" *
+%      capitalize
+%   "(" swap$ * ")" *
       *
     }
   if$
@@ -870,13 +882,13 @@ FUNCTION {format.book.pages}
 FUNCTION {format.doi}
 { doi empty$
     { "" }
-    { 
+    {
       urldate empty$
       {
-        "\url{https://doi.org/" doi * "}" *
+        "\doi{https://doi.org/" doi * "}" *
       }
       {
-        "at \url{https://doi.org/" doi * "}" *
+        "at \doi{https://doi.org/" doi * "}" *
       }
       if$
     }
@@ -885,9 +897,9 @@ FUNCTION {format.doi}
 FUNCTION {format.urldate}
 { urldate empty$
     { "" }
-    { 
+    {
       url empty$
-      { 
+      {
          doi empty$
          { "" }
          {
@@ -905,9 +917,9 @@ FUNCTION {format.urldate}
 FUNCTION {format.url}
 { url empty$
     { "" }
-    { 
+    {
       urldate empty$
-      { 
+      {
         "\url{" url * "}" *
       }
       {
@@ -920,7 +932,7 @@ FUNCTION {format.url}
 FUNCTION {format.urllink}
 { urllink empty$
     { "" }
-    { 
+    {
       " (Available online at \url{" urllink * "})" *
     }
   if$
@@ -1126,8 +1138,13 @@ FUNCTION {n.dashify}
 }
 
 FUNCTION {word.in}
-{ bbl.in 
+{ bbl.in
   " " * }
+
+FUNCTION {word.of}
+{ bbl.of
+  " " * }
+
 
 FUNCTION {format.date}
 { year "year" bibinfo.check duplicate$ empty$
@@ -1139,56 +1156,6 @@ FUNCTION {format.date}
   before.all 'output.state :=
   ", " swap$ * "" *
 }
-FUNCTION {format.btitle}
-{ title "title" bibinfo.check
-  duplicate$ empty$ 'skip$
-    {
-      %emphasize
-    }
-  if$
-}
-FUNCTION {either.or.check}
-{ empty$
-    'pop$
-    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
-  if$
-}
-FUNCTION {format.bvolume}
-{ volume empty$
-    { "" }
-    { bbl.volume volume tie.or.space.prefix
-      "volume" bibinfo.check * *
-      series "series" bibinfo.check
-      duplicate$ empty$ 'pop$
-      
-      %  { emphasize ", " * swap$ * } % REMOVE ITALICS FOR USGS
-        {  ", " * swap$ * }
-      if$
-      "volume and number" number either.or.check
-    }
-  if$
-}
-FUNCTION {format.number.series}
-{ volume empty$
-    { number empty$
-        { series field.or.null }
-        { series empty$
-            { number "number" bibinfo.check }
-            { output.state mid.sentence =
-                { bbl.number }
-                { bbl.number capitalize }
-              if$
-              number tie.or.space.prefix "number" bibinfo.check * *
-              bbl.in space.word *
-              series "series" bibinfo.check *
-            }
-          if$
-        }
-      if$
-    }
-    { "" }
-  if$
-}
 
 FUNCTION {format.edition}
 { edition duplicate$ empty$ 'skip$
@@ -1198,10 +1165,51 @@ FUNCTION {format.edition}
         { "t" }
       if$ change.case$
       "edition" bibinfo.check
-      " " * bbl.edition *
+      space.word
+      bbl.edition
     }
   if$
 }
+
+FUNCTION {format.btitle}
+{
+  title "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    {
+      %emphasize
+    }
+  if$
+  edition empty$ 'skip$
+    {
+      " (" * edition * " " * bbl.edition  * ")" *
+    }
+  if$
+}
+
+FUNCTION {either.or.check}
+{ empty$
+    'pop$
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+
+FUNCTION {format.bvolume}
+{ volume empty$
+    { "" }
+    {
+      bbl.volume volume tie.or.space.prefix
+      "volume" bibinfo.check * *
+      series "series" bibinfo.check
+      duplicate$ empty$ 'pop$
+
+      %  { emphasize ", " * swap$ * } % REMOVE ITALICS FOR USGS
+        {  ", " * swap$ * }
+      if$
+      "volume and number" number either.or.check
+    }
+  if$
+}
+
 INTEGERS { multiresult }
 FUNCTION {multi.page.check}
 { 't :=
@@ -1222,6 +1230,49 @@ FUNCTION {multi.page.check}
   while$
   multiresult
 }
+
+FUNCTION {format.numbers}
+{ number duplicate$ empty$ 'skip$
+    { duplicate$ multi.page.check
+        {
+          bbl.numbers swap$
+          n.dashify
+        }
+        {
+          bbl.number swap$
+        }
+      if$
+      tie.or.space.prefix
+      "number" bibinfo.check
+      * *
+    }
+  if$
+}
+
+FUNCTION {format.number.series}
+{ volume empty$
+    { number empty$
+        { series field.or.null }
+        { series empty$
+            { number "number" bibinfo.check }
+            { output.state mid.sentence =
+                % { bbl.number }
+                % { bbl.number capitalize }
+                { number format.numbers }
+                { number format.numbers capitalize }
+              if$
+              number tie.or.space.prefix "number" bibinfo.check * *
+              bbl.in space.word *
+              series "series" bibinfo.check *
+            }
+          if$
+        }
+      if$
+    }
+    { "" }
+  if$
+}
+
 FUNCTION {format.pages}
 { pages duplicate$ empty$ 'skip$
     { duplicate$ multi.page.check
@@ -1239,6 +1290,7 @@ FUNCTION {format.pages}
     }
   if$
 }
+
 FUNCTION {format.journal.pages}
 { pages duplicate$ empty$ 'pop$
     { swap$ duplicate$ empty$
@@ -1259,13 +1311,14 @@ FUNCTION {format.journal.eid}
   duplicate$ empty$ 'pop$
     { swap$ duplicate$ empty$ 'skip$
       {
-          ", " *
+          ", article " *
       }
       if$
       swap$ *
     }
   if$
 }
+
 FUNCTION {format.vol.num.pages}
 { volume field.or.null
   duplicate$ empty$ 'skip$
@@ -1275,21 +1328,63 @@ FUNCTION {format.vol.num.pages}
       * *
     }
   if$
-  number "number" bibinfo.check duplicate$ empty$ 'skip$
-    {
-      swap$ duplicate$ empty$
-        { "there's a number but no volume in " cite$ * warning$ }
-        'skip$
-      if$
-      swap$
-      ", " bbl.nr * number tie.or.space.prefix pop$ * swap$ *
-    }
-  if$ *
+  number empty$
+    { }
+    { ", " format.numbers * * }
+  if$
+%  number "number" bibinfo.check duplicate$ empty$ 'skip$
+%    {
+%      swap$ duplicate$ empty$
+%        { "there's a number but no volume in " cite$ * warning$ }
+%        'skip$
+%      if$
+%      swap$
+%      ", " bbl.number * number tie.or.space.prefix pop$ * swap$ *
+%    }
+%  if$ *
   eid empty$
     { format.journal.pages }
     { format.journal.eid }
   if$
 }
+
+FUNCTION {format.chapter}
+{
+  chapter empty$
+    {
+      bbl.in " " *
+    }
+    {
+      bbl.chapter " " *
+      chapter "chapter" bibinfo.check *
+      " " *
+      bbl.of *
+      " " *
+    }
+  if$
+}
+
+% { volume empty$
+%     { number empty$
+%         { series field.or.null }
+%         { series empty$
+%             { number "number" bibinfo.check }
+%             { output.state mid.sentence =
+%                 { bbl.number }
+%                 { bbl.number capitalize }
+%               if$
+%               number tie.or.space.prefix "number" bibinfo.check * *
+%               bbl.in space.word *
+%               series "series" bibinfo.check *
+%             }
+%           if$
+%         }
+%       if$
+%     }
+%     { "" }
+%   if$
+% }
+
 
 FUNCTION {format.chapter.pages}
 { chapter empty$
@@ -1319,7 +1414,7 @@ FUNCTION {format.booktitle}
 
 FUNCTION {format.editor}
 {
-  editor "editor" format.names 
+  editor "editor" format.names
   duplicate$ empty$ 'pop$
     {
       %emphasize
@@ -1348,7 +1443,7 @@ FUNCTION {format.in.ed.booktitle}
 }
 
 FUNCTION {formatc.in.ed.booktitle}
-{ format.editor duplicate$ empty$ 'skip$
+{ format.editors duplicate$ empty$ 'skip$
     {
       format.bvolume duplicate$ empty$ 'pop$
         { ", " swap$ * * }
@@ -1360,7 +1455,8 @@ FUNCTION {formatc.in.ed.booktitle}
           " " * swap$
           * }
       if$
-      word.in swap$ *
+%      word.in swap$ *
+      format.chapter swap$ *
     }
   if$
 }
@@ -1445,10 +1541,10 @@ FUNCTION {formatc.org.or.pub}
   if$
 }
 FUNCTION {format.publisher.address}
-{ format.org.or.pub publisher "publisher" bibinfo.warn 
+{ format.org.or.pub publisher "publisher" bibinfo.warn
 }
 FUNCTION {formatc.publisher.address}
-{ formatc.org.or.pub publisher "publisher" bibinfo.warn 
+{ formatc.org.or.pub publisher "publisher" bibinfo.warn
 }
 
 FUNCTION {format.organization.address}
@@ -1534,21 +1630,25 @@ FUNCTION {inbook}
     { format.editors "author and editor" output.check
       editor format.key output
     }
-    { format.authors output.nonnull
-      crossref missing$
-        { "author and editor" editor either.or.check }
-        'skip$
-      if$
+    {
+      format.authors "author" output.check
+      author format.key output
     }
   if$
   format.date "year" output.check
   date.block
   format.btitle "title" output.check
   publisher empty$
-    { format.number.series outputc.nonnull }
-    { formatc.publisher.address output
-      format.book.pages output
-    }
+  {
+    formatc.in.ed.booktitle "booktitle" output.check
+    format.number.series outputc.nonnull
+    format.pages output
+  }
+  {
+    formatc.in.ed.booktitle "booktitle" output.check
+    formatc.publisher.address output
+    format.pages output
+  }
 %  crossref missing$
 %    {
 %      format.bvolume output
@@ -1578,11 +1678,13 @@ FUNCTION {incollection}
   date.block
   format.title "title" output.check
   publisher empty$
-    { formatc.in.ed.booktitle "booktitle" output.check
+    {
+      formatc.in.ed.booktitle "booktitle" output.check
       format.number.series outputc.nonnull }
-    { formatc.in.ed.booktitle "booktitle" output.check
+    {
+      formatc.in.ed.booktitle "booktitle" output.check
       formatc.publisher.address output
-      format.book.pages output
+      format.pages output
     }
 %  crossref missing$
 %    { format.in.ed.booktitle "booktitle" output.check
@@ -1752,7 +1854,7 @@ FUNCTION {online}
   format.title
   "title" output.check
  % format.tr.number emphasize output.nonnull
-	
+
   fin.entry
 }
 
@@ -2062,9 +2164,9 @@ FUNCTION {begin.bib}
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax"
   write$ newline$
-  "  \providecommand{\doi}[1]{doi:\discretionary{}{}{}#1}\else"
+  "  \providecommand{\doiagency}[1]{doi:\discretionary{}{}{}#1}\else"
   write$ newline$
-  "  \providecommand{\doi}{doi:\discretionary{}{}{}\begingroup \urlstyle{rm}\Url}\fi"
+  "  \providecommand{\doiagency}{doi:\discretionary{}{}{}\begingroup \urlstyle{rm}\Url}\fi"
   write$ newline$
 }
 EXECUTE {begin.bib}

--- a/usgsLaTeX/tex/latex/usgs/usgsattr.sty
+++ b/usgsLaTeX/tex/latex/usgs/usgsattr.sty
@@ -91,7 +91,7 @@
 
 \newcommand{\theauthorslastfirst}{} % suitable for citations
 
-\newcommand{\doi}{U.S.~Department of the Interior}
+\newcommand{\doiagency}{U.S.~Department of the Interior}
 
 \newcommand{\doisecretary}{Ryan K. Zinke}
 

--- a/usgsLaTeX/tex/latex/usgs/usgsbib.sty
+++ b/usgsLaTeX/tex/latex/usgs/usgsbib.sty
@@ -7,6 +7,7 @@
 \RequirePackage{natbib}
 \RequirePackage{color}
 \RequirePackage{url}
+\RequirePackage{doi}
 %------------------------ declaration of options ----------
 %------------------------ execution of options
 \ProcessOptions \relax
@@ -28,11 +29,13 @@
 % the heading. This might be useful in some circumstances.
 \newcommand{\refpreamble}{}
 
+\renewcommand{\doitext}{} % use empty string instead of doi: prior to doi
+
 \newcommand{\REFSECTION}
 {\SECTION{\reportrefname}
  \refpreamble}
 % Often USGS reports have 'Selected References'
-% Therefore, redefinition of \reportrefname in the preamble 
+% Therefore, redefinition of \reportrefname in the preamble
 % to 'Selected References' would be required.
 
 \setlength\bibsep{2pt} % separation space between each reference,
@@ -66,8 +69,8 @@
 % command is redefined. If on the other hand, this package is loaded
 % after hyperref the \providecommand does not renew the \href out from
 % underneath us.
-\providecommand{\href}[2]{\refnotetext}    
-\newcommand{\hyperrefmarlabel}{} % perhaps $\Leftarrow$ ???            
+\providecommand{\href}[2]{\refnotetext}
+\newcommand{\hyperrefmarlabel}{} % perhaps $\Leftarrow$ ???
 \newcommand{\hyperrefnote}[1]
 {\hfill \makebox[\refnotewidth][\refnotejustify]%
                 {{\refnotefont \refnotecolor
@@ -77,7 +80,7 @@
 
 % Perhaps you want the actual url address? Use the \hyperrefnoteurl
 % command. The same color is used by the \refnotecolor and the
-% bounding [  ] provide the USGS style of extra information in a 
+% bounding [  ] provide the USGS style of extra information in a
 % reference. The user is responsible for adding a \linebreak at the tail
 % of the reference (see the example below)
 
@@ -102,8 +105,8 @@
                            \url{#1}}\nolinebreak[4]\hspace{.25ex}]}}
  \usebox{\@refnoteurl}
 }
-                
-   
+
+
 \newcommand{\refnotejustify}{l} % will have no visible effect
 % unless width is other than \width
 \newcommand{\refnotewidth}{\width} % \width is the width of the text

--- a/usgsLaTeX/tex/latex/usgs/usgsreporta.sty
+++ b/usgsLaTeX/tex/latex/usgs/usgsreporta.sty
@@ -18,7 +18,7 @@
 % the usgsreporta.sty package
 
 \RequirePackage{indentfirst} % indent first line of regular
-% paragraphs, which is against American typographic tradition and 
+% paragraphs, which is against American typographic tradition and
 % default LaTeX.
 
 \RequirePackage{epic} % for the picture environ. for the cover work
@@ -40,9 +40,9 @@
 
 
 \RequirePackage{fancybox} % for the \fancyput as part of the draft
-% option of the usgsreporta package. This command places the 
+% option of the usgsreporta package. This command places the
 % 'watermark' like text at bottom of cover and report body containing
-% the Date of the typesetting and the USGS provisional message     
+% the Date of the typesetting and the USGS provisional message
 
 \RequirePackage{eso-pic}
 \RequirePackage{wallpaper}
@@ -165,7 +165,7 @@
 % take effect. LaTeX2e provides the \linespread declaration
 % \linespread{1.5}\selectfont (see TLC p. 107)
 % \stretchbaseline returns use to regular line spacing
-% \stretchbaseline[1.07] might stretch the text two lines in a 
+% \stretchbaseline[1.07] might stretch the text two lines in a
 % single column--don't forget to switch back to \stretchbaseline
 % AS SOON AS YOU DON'T NEED THE INCREASED SPACING
 % Because the \doublespacing command provided by the setspace package
@@ -207,11 +207,11 @@
   \setlength{\@coresecaftersep}{\secaftersep}
   \setlength{\secbeforesep}{0pt}
   \setlength{\secaftersep}{\contentsaftersep}
-  
+
   \vspace*{\contentsbeforesep}
-  
+
   \tableofcontents
-  %\rule{1pt}{0.3125in} used to page measure the 
+  %\rule{1pt}{0.3125in} used to page measure the
   %needed offset between Contents and Abstract
   %as actually controlled by the \contentsaftersep
 
@@ -219,14 +219,14 @@
   \setlength{\secaftersep}{\@coresecaftersep}
 
   \pagestyle{toc}
-  %\tolerance=700 % diverage the interword spacing to 
+  %\tolerance=700 % diverage the interword spacing to
   % higher for loose typesetting--this helps to get
   % the dots after the contents to fill correctly
   % when the contents fully fits the justified paragraph
   \ifthenelse{\boolean{figuretoc}}{\listoffigures}{}
   \ifthenelse{\boolean{tabletoc}}{\listoftables}{}
   %\tolerance=200
-  % The conversion page would follow say with a 
+  % The conversion page would follow say with a
   % \conversionpage command, but that page is distinctly
   % different from the list like pages of shown here.
   % See the \makefrontmatter command for the conversions and
@@ -253,7 +253,7 @@
 \setlength{\GSphotogap}{0.4in}
 
 
-% define a horizontal separation distance on the left of the 
+% define a horizontal separation distance on the left of the
 % cover photograph
 \newlength{\GSphotohsep}
 \setlength{\GSphotohsep}{0in}
@@ -301,7 +301,7 @@
 }
 
 \newcommand{\makefirstpagetop}
-{ \twocolumn[\topfirstpage] % begin the mainmatter with 
+{ \twocolumn[\topfirstpage] % begin the mainmatter with
    % the column spanning title of report and the authors
    \thispagestyle{plain}
    \fancypagestyle{plain}{\pagestyle{bodyplain}}
@@ -312,8 +312,8 @@
 
    \normalsize % ensure that we are in normal size text
    \rmfamily   % and the we are setting in roman
-   
-   % Finally if in draft mode toggle remainder of the 
+
+   % Finally if in draft mode toggle remainder of the
    % body of the manuscript
    \ifthenelse{\boolean{draft}}{\DoDraftElementsMainMatter}{}
 }
@@ -328,8 +328,8 @@
 
    \normalsize % ensure that we are in normal size text
    \rmfamily   % and the we are setting in roman
-   
-   % Finally if in draft mode toggle remainder of the 
+
+   % Finally if in draft mode toggle remainder of the
    % body of the manuscript
    \ifthenelse{\boolean{draft}}{\DoDraftElementsMainMatter}{}
 }
@@ -364,13 +364,13 @@
       \maketitle % make the title page from usgstitlepage.sty
       \makefly   % make the inside fly page usgstitlepage.sty
    \end{spacing}
-   
+
    \makepreface  % make preface
    \maketoc      % make the table of contents for the report
-   
+
    \conversionpage % make the request for setting the conversionpage
    % this command might produce nothing
-   
+
    \myblankpage % insert a potential blank page before body begins.
 
    \makefirstpagetop % finally initate main body startup sequence
@@ -391,14 +391,14 @@
       %\maketitle % make the title page from usgstitlepage.sty
       %\makefly   % make the inside fly page usgstitlepage.sty
    \end{spacing}
-   
+
    \makepreface
-        
+
    \maketoc % make the table of contents for the report
-   
+
    %\conversionpage % make the request for setting the conversionpage
    % this command might produce nothing
-   
+
    \myblankpage % insert a potential blank page before body begins.
 
    \makefirstpagetopalt % finally initate main body startup sequence
@@ -414,7 +414,7 @@
 \setlength\fboxrule{0pt} % but want to hide the rules, desire fboxes to help in layout
 \setlength{\unitlength}{0.01in} % sets the unit lengths for the
 % picture environment
-\newcommand{\pictureorigin}{\makebox(0,0){\tiny $\bullet$}} % a dot if 
+\newcommand{\pictureorigin}{\makebox(0,0){\tiny $\bullet$}} % a dot if
 % origin needs to be seen, this is not a command for final production,
 % but is a helpful tool when working with the picture environment
 
@@ -435,13 +435,13 @@
    \bannercolor % set color of the banner that is drawn by
    % the command \coverruleevenpage
    \covercolor % set color of the cover page--typically not white
-    
+
    \noindent
    \begin{picture}(0,0)
       %\put(0,0){\pictureorigin} % the origin
       \coverruleoddpage % banner across the top
       \visidcolor
-      \put(-25,37){ 
+      \put(-25,37){
          \fbox{\includegraphics[height=0.5in,
                 trim=1.37in 4.535in 1.437in 4.323in,
                 clip]{\USGSvisidname}}
@@ -454,14 +454,14 @@
 
    \noindent
    \begin{picture}(0,0)
-      \put(-25,13){\noindent 
+      \put(-25,13){\noindent
          \parbox[b]{\textwidth}
          {\normalsize \bfseries \sffamily
            \cooperationwith
          } \hspace*{\fill} % end the parbox
       } % end of the put
    \end{picture}
-   
+
    \rule[0in]{0in}{0.25in}
 
    \noindent
@@ -476,7 +476,7 @@
          } % end of the outer parbox
       } % end of the put
    \end{picture}
-        
+
    \vspace*{\GSphotogap}
 
    {\setlength\fboxrule{\GSphotorule} \setlength\fboxsep{\GSphotosep}
@@ -489,10 +489,10 @@
        }
     \end{picture}
     \color{black}
-   }  
+   }
    \color{black}
    \vspace*{\fill} % rubber space to fill in the setup
-     
+
    \noindent
    \begin{picture}(0,0)
       \put(-25,0){\noindent
@@ -500,22 +500,22 @@
             {\noindent
              \parbox{\textwidth}
                 {\LARGE
-                 \textsf{\reportseries\ \reportnumber 
+                 \textsf{\reportseries\ \reportnumber
                          \cooperatorreportseries } \hspace*{\fill}
                 }
-                
+
              %\fbox{\rule[0in]{0cm}{\coopTOseries}}
              \rule[0in]{0cm}{2\seriesTOdoi}
 
              \noindent
              \parbox{\textwidth}
-                {\large \bfseries \textsf{\doi \\ \textusgs} }
-                
+                {\large \bfseries \textsf{\doiagency \\ \textusgs} }
+
          } % end the parbox
       } % end of the put
    \end{picture}
    \clearpage
-    
+
    % now typeset the back of the front cover page
    \pagestyle{title}
    \onecolumn
@@ -524,7 +524,7 @@
    \noindent
    \begin{picture}(0,0)
       \put(0,0){\noindent
-         \mbox{\sffamily \footnotesize \textbf{Cover.}}\ 
+         \mbox{\sffamily \footnotesize \textbf{Cover.}}\
          \parbox[t]{0.6\textwidth}
             {\raggedright \sffamily \footnotesize \GSphotocredit}
       } % end of the put
@@ -555,16 +555,16 @@
    \bannercolor % set color of the banner that is drawn by
    % the command \coverruleevenpage
    %\covercolor % set color of the cover page--typically not white
-   
+
    %\AddToShipoutPictureBG*{\BackgroundPic}
    \ThisTileWallPaper{\paperwidth}{1.25\paperheight}{\coverphoto}
-    
+
    \noindent
    \begin{picture}(0,0)
       %\put(0,0){\pictureorigin} % the origin
       \coverruleoddpage % banner across the top
       \visidcolor
-      \put(-25,43){ 
+      \put(-25,43){
          \fbox{\includegraphics[height=0.5in,
                 trim=1.37in 4.535in 1.437in 4.323in,
                 clip]{\USGSvisidname}}
@@ -578,14 +578,14 @@
    % Prepared in cooperation with ...
    \noindent
    \begin{picture}(0,0)
-      \put(-25,13){\noindent 
+      \put(-25,13){\noindent
          \parbox[b]{\textwidth}
          {\titlefontlarge \bfseries \sffamily
            \cooperationwith
          } \hspace*{\fill} % end the parbox
       } % end of the put
    \end{picture}
-   
+
    \rule[0in]{0in}{0.25in}
 
    % Title
@@ -622,10 +622,10 @@
       } % end of the put
    \end{picture}
 
-        
+
    \color{white}
    \vspace*{\fill} % rubber space to fill in the setup
-     
+
    \noindent
    \begin{picture}(0,0)
       \put(-25,0){\noindent
@@ -634,24 +634,24 @@
              \parbox{\textwidth}
                 {\huge
                  \fontseries{l}\selectfont
-                 \textsf{\reportseries\ \reportnumber 
+                 \textsf{\reportseries\ \reportnumber
                          \cooperatorreportseries \\ \reportversion} \hspace*{\fill}
                 }
-                
+
              %\fbox{\rule[0in]{0cm}{\coopTOseries}}
              \rule[0in]{0cm}{2\seriesTOdoi}
 
              \noindent
              \parbox{\textwidth}
-                {\large \bfseries \textsf{\doi \\ \textusgs} }
-                
+                {\large \bfseries \textsf{\doiagency \\ \textusgs} }
+
          } % end the parbox
       } % end of the put
    \end{picture}
-   
+
    \color{black}
    \clearpage
-    
+
    % now typeset the back of the front cover page
    \pagestyle{title}
    \onecolumn
@@ -660,7 +660,7 @@
    \noindent
    \begin{picture}(0,0)
       \put(0,0){\noindent
-         \mbox{\sffamily \footnotesize \textbf{Cover.}}\ 
+         \mbox{\sffamily \footnotesize \textbf{Cover.}}\
          \parbox[t]{0.6\textwidth}
             {\raggedright \sffamily \footnotesize \GSphotocredit}
       } % end of the put
@@ -690,14 +690,14 @@
       \put(-25,0){\noindent
          \parbox[b]{0.9\textwidth}
             {\colophontextsize \sffamily
-            
+
              \ifdef{\customcolophon}{\customcolophon}{
              \productionstaff \\
-             \colophoninfo    \\ \\ 
+             \colophoninfo    \\ \\
              \theoffice       \\
              \theofficewebsite}
-             
-             
+
+
             } % end of the parbox
       } % end of the put
    \end{picture}
@@ -732,7 +732,7 @@
          %\put(0,0){\pictureorigin} % the origin
          \coverruleevenpage
          \visidcolor
-         \put(-118,25){\rule{\paperwidth}{0in} 
+         \put(-118,25){\rule{\paperwidth}{0in}
             \fbox{\rotatebox[y=.4825in]{270}{
                \includegraphics[width=.5in,
                   trim=1.37in 5.05in 1.437in 4.323in,
@@ -757,12 +757,12 @@
         \put(0,-870){\noindent \hspace{5.6in}
           \parbox[t]{\textwidth}
                     {\tiny
-                     \href{\reportwebsiteroot \reportwebsiteremainder}{\reportwebsiteroot \reportwebsiteremainder} 
+                     \href{\reportwebsiteroot \reportwebsiteremainder}{\reportwebsiteroot \reportwebsiteremainder}
                      }}
       \end{picture}
-    
+
       \vspace{0.5in}
-    
+
       \noindent
       \makebox[\backcoveroffset][r]{\noindent
          \rotatebox[origin=c]{270}{\noindent
@@ -772,7 +772,7 @@
             } % end of the fbox
          } % end of the rotatebox
       } % end of the makebox
-    
+
       \vspace*{\fill}
       \clearpage
    \end{spacing}
@@ -781,4 +781,3 @@
 
 
 \endinput
-

--- a/usgsLaTeX/tex/latex/usgs/usgstitlepage.sty
+++ b/usgsLaTeX/tex/latex/usgs/usgstitlepage.sty
@@ -51,9 +51,9 @@
    \onecolumn
    \thispagestyle{plain}
    \fancypagestyle{plain}{\pagestyle{title}}
-   
+
    {\titlefontfamilyA
-   
+
    \noindent \begin{picture}(0,0)
       \put(0,-600){\noindent \hspace*{\titlepagehspace}
          \parbox[t]{\titlepagewidth}
@@ -66,25 +66,23 @@
                    {\titlefontlarge \textsf{\tandmchap} \\
                     \large \textsf{\tandmsec} \\
                     \titlefontLarge \bfseries \textsf{\tandmbook} }}
-              
+
       \put(0,-6345){\noindent \hspace*{\titlepagehspace}
          \parbox[t]{\titlepagewidth}
                    {\titlefontlarge \cooperationwith}}
-              
+
     \put(0,-8205){\noindent  \hspace*{\titlepagehspace}
       \parbox[b]{\titlepagewidth}
              {\titlefontfamilyB \titlefontLarge
-               \reportseries\ \reportnumber \\ 
+               \reportseries\ \reportnumber \\
                \cooperatorreportseries}}
 
      \put(0,-9115){\noindent \hspace*{\titlepagehspace}
            \parbox[b]{\titlepagewidth}
-                     {\titlefontlarge \bfseries \doi \\ \textusgs}}
+                     {\titlefontlarge \bfseries \doiagency \\ \textusgs}}
       \end{picture}
    }
 }
 
 
 \endinput
-
-


### PR DESCRIPTION
Add doi package import to deal with nasty characters in doi. Required
USGS style file \doi command that results in "U.S. Department of
Interior" to be redefined as \doiagency.