### PR TITLE
feat(Docker): add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM texlive/texlive
+RUN apt-get update && apt-get install -y \
+    texlive-latex-extra \
+    texlive-science \
+    texlive-font-utils \
+    texlive-fonts-recommended \
+    texlive-fonts-extra \
+    python3 \
+    python3-pip \
+    dos2unix
+RUN git clone https://github.com/MODFLOW-USGS/usgslatex.git && cd usgslatex/usgsLaTeX && ./install.sh --all-users
+RUN pip install flaky flopy mfpymake modflow-devtools pytest


### PR DESCRIPTION
Introduces a Docker image for this repo. This allows building docs [in a versionable container](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container) rather than downloading/installing LaTeX and this repo on each CI run. It also provides an alternative for building the docs locally.