### PR TITLE
Update Windows install instructions and add no-admin install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     These installation installation instructions may work for other
     TeX distributions but this has not been tested.
 
-2. Clone the [`usgslatex`](https://github.com/MODFLOW-USGS/usgslatex)
+2. Clone the [`usgslatex`](https://github.com/MODFLOW-ORG/usgslatex)
     repository to a location of your choice on your computer. On
     `Windows`, the `usgslatex` repository should be cloned to your `C:`
     drive for the installation file to work correctly.
@@ -37,13 +37,24 @@
         `/usr/local/texlive/2021/texmf-var/fonts/`) for a specific
         TeX Live distribution.
 
-    3. To install the Univers Condensed font library and USGS style
-        files on `Windows`, run `install.bat` in the `usgsLaTeX`
-        subdirectory in your local clone of the `usgslatex` repository
-        as an Adminstrator by right-clicking on the file and selecting
-        "Run as administration". Similar to installing the Univers Condensed 
-        font library andUSGS style files on `MacOS` and `Linux`, `install.bat` 
-        is run asan Administrator so that system files can be modified.
+    2. To install the Univers Condensed and Times New Roman font
+        libraries and USGS style files on `Windows`, run `install.bat`
+        in the `usgsLaTeX` subdirectory of your local clone of the
+        `usgslatex` repository. You can run it by double-clicking the
+        file or by calling it from a terminal; `.bat` files run from
+        both `cmd` and `PowerShell`, so a separate PowerShell script is
+        not needed.
+
+        `install.bat` automatically chooses where to install: if
+        `TEXMFLOCAL` (the local texmf tree reported by
+        `kpsewhich -var-value TEXMFLOCAL`) is writable, it installs
+        system-wide using `updmap-sys`; otherwise it falls back to your
+        per-user tree `TEXMFHOME` using `updmap-user`, which never
+        requires Administrator privileges. As a result you normally do
+        not need to elevate. If you specifically want a system-wide
+        installation on a machine where `TEXMFLOCAL` is owned by an
+        administrator, right-click `install.bat` and select
+        "Run as administrator".
 
 4. If the USGS style files have been correctly installed you should see
     something like the following on the last three lines of the output
@@ -54,7 +65,7 @@
         ```              
             Evaluate if USGS style files are available
             Location of USGS LaTeX style files:  
-            /Users/jdhughes/Library/texmf/tex/latex/usgs/usgsreporta.sty
+            /Users/<username>/Library/texmf/tex/latex/usgs/usgsreporta.sty
         ```
         
     2.  On `Windows` you should see something like
@@ -64,6 +75,11 @@
             Location of USGS LaTeX style files:  
             c:/texlive/texmf-local/tex/latex/usgs/usgsreporta.sty
         ```
+
+        If `install.bat` performed a per-user installation (because
+        `TEXMFLOCAL` was not writable), the reported path will instead
+        be under your home texmf tree, for example
+        `C:/Users/<username>/texmf/tex/latex/usgs/usgsreporta.sty`.
 
 5. Test the Installation of the Univers Condensed font library
     installation can be tested using the `testunivers.tex` TeXfile in

--- a/usgsLaTeX/install.bat
+++ b/usgsLaTeX/install.bat
@@ -1,54 +1,65 @@
-cls
-echo off
+@echo off
+setlocal enabledelayedexpansion
 
-cd > result.txt
-set CURRENT=%~dp0
-echo Current drive=%CURRENT:~0,3%
+set "CURRENT=%~dp0"
 echo Current directory=%CURRENT%
 
-kpsewhich -var-value TEXMFLOCAL > result.txt
-set /p TEXLOCAL=<result.txt
+REM --- Locate the system-wide (TEXMFLOCAL) and per-user (TEXMFHOME) trees ---
+for /f "usebackq delims=" %%i in (`kpsewhich -var-value TEXMFLOCAL`) do set "TEXLOCAL=%%i"
+for /f "usebackq delims=" %%i in (`kpsewhich -var-value TEXMFHOME`) do set "TEXHOME=%%i"
 set "TEXLOCAL=%TEXLOCAL:/=\%"
-echo TEXLOCAL Drive=%TEXLOCAL:~0,3%
-echo TEXLOCAL=%TEXLOCAL%
+set "TEXHOME=%TEXHOME:/=\%"
+echo TEXMFLOCAL=%TEXLOCAL%
+echo TEXMFHOME=%TEXHOME%
 
-echo Making a few directories if they do not exist..."
-mkdir %TEXLOCAL%
-mkdir %TEXLOCAL%\tex\
-mkdir %TEXLOCAL%\bibtex\
-mkdir %TEXLOCAL%\fonts\
-mkdir %TEXLOCAL%\dvips\
+REM --- Decide the target tree based on write access to TEXMFLOCAL. ---
+REM     If TEXMFLOCAL is writable (e.g. you own the TeX Live installation,
+REM     or you are running elevated), install system-wide with updmap-sys.
+REM     Otherwise fall back to the per-user tree TEXMFHOME with updmap-user,
+REM     which never requires Administrator privileges.
+if not exist "%TEXLOCAL%" mkdir "%TEXLOCAL%" 2>nul
+set "WRITABLE=1"
+copy /y nul "%TEXLOCAL%\.usgs_wtest" >nul 2>&1 || set "WRITABLE=0"
+if exist "%TEXLOCAL%\.usgs_wtest" del /q "%TEXLOCAL%\.usgs_wtest" >nul 2>&1
 
-echo "Copying USGS LaTeX style files...
+if "%WRITABLE%"=="1" (
+    set "TEXROOT=%TEXLOCAL%"
+    set "UPDMAP=updmap-sys"
+    echo TEXMFLOCAL is writable -- installing system-wide.
+) else (
+    set "TEXROOT=%TEXHOME%"
+    set "UPDMAP=updmap-user"
+    echo TEXMFLOCAL is not writable -- installing for the current user only ^(no Administrator privileges required^).
+)
+echo Target tree: !TEXROOT!
+echo Font-map tool: !UPDMAP!
 
-echo Copy %CURRENT%\tex to %TEXLOCAL%\tex
-Xcopy %CURRENT%\tex %TEXLOCAL%\tex /E /F /Y
+echo Making a few directories if they do not exist...
+mkdir "!TEXROOT!"         2>nul
+mkdir "!TEXROOT!\tex"     2>nul
+mkdir "!TEXROOT!\bibtex"  2>nul
+mkdir "!TEXROOT!\fonts"   2>nul
+mkdir "!TEXROOT!\dvips"   2>nul
 
-echo Copy %CURRENT%\bibtex to %TEXLOCAL%\bibtex
-Xcopy %CURRENT%\bibtex %TEXLOCAL%\bibtex /E /F /Y
+echo Copying USGS LaTeX style files...
+Xcopy "%CURRENT%tex"    "!TEXROOT!\tex"    /E /F /Y
+Xcopy "%CURRENT%bibtex" "!TEXROOT!\bibtex" /E /F /Y
+Xcopy "%CURRENT%fonts"  "!TEXROOT!\fonts"  /E /F /Y
+Xcopy "%CURRENT%dvips"  "!TEXROOT!\dvips"  /E /F /Y
 
-echo Copy %CURRENT%\fonts to %TEXLOCAL%\fonts
-Xcopy %CURRENT%\fonts %TEXLOCAL%\fonts /E /F /Y
-
-echo Copy %CURRENT%\dvips to %TEXLOCAL%\dvips
-Xcopy %CURRENT%\dvips %TEXLOCAL%\dvips /E /F /Y
-
-echo Installing Univers font...
-cd %TEXLOCAL%\dvips
-updmap-sys --enable Map=funivers.map
-updmap-sys
+echo Installing Univers Condensed font...
+cd /d "!TEXROOT!\dvips"
+!UPDMAP! --enable Map=funivers.map
+!UPDMAP!
 
 echo Installing Times New Roman font...
-cd %TEXLOCAL%\dvips
-updmap-sys --enable Map=timesnew.map
-updmap-sys
+!UPDMAP! --enable Map=timesnew.map
+!UPDMAP!
 
-echo Rebuild ls-R filename databases used by TeX...
-mktexlsr
+echo Rebuild ls-R filename database used by TeX...
+mktexlsr "!TEXROOT!"
 
-echo Return to %CURRENT%
-cd %CURRENT%
-
+cd /d "%CURRENT%"
 echo Evaluate if USGS style files are available
 echo Location of USGS LaTeX style files:
 kpsewhich usgsreporta.sty


### PR DESCRIPTION
## Summary
Makes the Windows installation work for users **without** Administrator privileges (e.g. an IT-managed, system-wide TeX Live), and brings the README instructions up to date.

## `usgsLaTeX/install.bat`
- **Auto-detect target tree:** install system-wide to `TEXMFLOCAL` with `updmap-sys` when it is writable; otherwise fall back to the per-user `TEXMFHOME` with `updmap-user`, which never requires elevation.
- Quote paths for robustness; install both **Univers Condensed** and **Times New Roman** font maps.

## `README.md`
- Document the auto-detect behavior; clarify that elevation is normally unnecessary.
- Fix the Administrator typos and the mis-numbered sub-item; note that `.bat` runs from PowerShell as well as `cmd`.
- Anonymize the macOS success-message path (`username` → `<username>`).
- Update the repository URL from `MODFLOW-USGS` to `MODFLOW-ORG`.

## Testing
- System-wide branch verified on a per-user TeX Live 2026 install: detected writable `TEXMFLOCAL`, installed, and `kpsewhich usgsreporta.sty` resolves.
- No-admin branch mechanisms verified: writability probe returns "not writable" for an unwritable location; files in `TEXMFHOME` are found by `kpsewhich`; `updmap-user` is present and functional.
- `USGSLaTeXReport.tex` compiles (12 pages) with the USGS class and both fonts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
